### PR TITLE
Fix a number of issues in `topt.c`

### DIFF
--- a/src/topt.c
+++ b/src/topt.c
@@ -1,66 +1,125 @@
 /*
-Simple utility to translate a binary file, character by character
-into lines composed of three octal digits. 
+ * Translates every byte in the program's input to
+ * a printable line of three octal digits.  Outputs
+ * to stdout or a named file given with the `-o`
+ * option.  Default input is stdin.  If multiple
+ * named files are given, they are concatenated into
+ * a single output "tape".
+ *
+ * For example, a file that contains "ABC" will be
+ * translated to "101\n102\n103\n".
+ *
+ * usage: topt [-t] [-o outfile] [file...]
+ *
+ * Use `-t` for text files to add a carriage return before
+ * each newline and set the high bit in each output byte.
+ *
+ * Remember that the emulator requires that output files
+ * have a `.txt` extension.
+ */
 
-So a file that contains "ABC" 
-will be translated to: 101\n102\n103\n
-
-use -t for text files.  It will add \r before each \n
-
-usage: topt [-t] <infile >outfile
-
-Remember that paper tapes must have a .txt extension.
-*/
-
+#include <ctype.h>
+#include <errno.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
+#include <unistd.h>
 
-void putCharInOctal(int c) {
-	putchar('0'+((c>>6)&7));
-	putchar('0'+((c>>3)&7));
-	putchar('0'+(c&7));
-	putchar('\n');
-}
+typedef unsigned char byte;
 
-void leader(int n) {
-	for (int i=0; i<n; i++)	
-		putCharInOctal(0200);
-}
+const int HIGH_BIT = 0200;
 
-int main(int ac, char** av) {
-	int textFlag = 0;
-	
-	if (ac > 2) {
-		fprintf(stderr, "usage topt [-t] <infile >outfile\n");
-		exit(1);
-	}
-	
-	av++;
+static void leader(int n, FILE *outFile);
+static void convertFileToOctal(FILE *inFile, bool textMode, FILE *outFile);
+static void putByteInOctal(byte b, FILE *outFile);
+static void usage(void);
 
-	if (strcmp(*av, "-t") == 0) {
-		fprintf(stderr, "text mode.\n");
-		textFlag = 1;
-	}
-	
-	leader(10);
-
+int main(int argc, char *argv[]) {
 	int c;
-	while ((c = getchar()) != EOF) {
-		if (textFlag) {
-			c|=0200;
-			if (c >= 0341 && c <= 0372) // lower case
-				c-=040; //toupper
-			if (c == 0376) // ~ -> ^L
-				c = 0214; // ^L
-			if (c == 0212) //lf
-				putCharInOctal(0215);//cr
+	bool textFlag = false;
+	char *inFileName, *outFileName;
+	FILE *inFile, *outFile = stdout;
+
+	while ((c = getopt(argc, argv, "to:")) != -1) {
+		switch (c) {
+		case 'o':
+			outFileName = optarg;
+			outFile = fopen(outFileName, "w");
+			if (outFile == NULL) {
+				fprintf(stderr,
+				    "Error opening '%s' for writing: %s\n",
+				    outFileName, strerror(errno));
+				return EXIT_FAILURE;
+			}
+		case 't':
+			fprintf(stderr, "text mode.\n");
+			textFlag = true;
+			break;
+		default:
+			usage();
+			break;
 		}
-		putCharInOctal(c);
 	}
-		
-	leader(10);
+	argc -= optind;
+	argv += optind;
+
+	leader(10, outFile);
+	if (argc == 0)
+		convertFileToOctal(stdin, textFlag, outFile);
+	else
+		while ((inFileName = *argv++) != NULL) {
+			if (strcmp(inFileName, "-") == 0) {
+				convertFileToOctal(stdin, textFlag, outFile);
+				continue;
+			}
+			inFile = fopen(inFileName, "r");
+			if (inFile == NULL) {
+				fprintf(stderr,
+				    "Error opening '%s' for reading: %s\n",
+				    inFileName, strerror(errno));
+				fclose(outFile);
+				return EXIT_FAILURE;
+			}
+			convertFileToOctal(inFile, textFlag, outFile);
+			fclose(inFile);
+		}
+	leader(10, outFile);
+	fclose(outFile);
+
+	return EXIT_SUCCESS;
 }
 
+static void leader(int n, FILE *outFile) {
+	for (int i = 0; i < n; i++)
+		putByteInOctal(HIGH_BIT, outFile);
+}
 
+static void convertFileToOctal(FILE *inFile, bool textFlag, FILE *outFile) {
+	const int NL = 012;	// Newline
+	const int FF = 014;	// Form feed (^L)
+	const int CR = 015;	// Carriage return
+	int c;
+
+	while ((c = fgetc(inFile)) != EOF) {
+		if (textFlag) {
+			if (isascii(c) && islower(c))
+				c = toupper(c);
+			if (c == '~')
+				c = FF;
+			if (c == NL)
+				putByteInOctal(CR | HIGH_BIT, outFile);
+			c |= HIGH_BIT;
+		}
+		putByteInOctal(c, outFile);
+	}
+}
+
+static void putByteInOctal(byte b, FILE *outFile) {
+	fprintf(outFile, "%03o\n", b);
+}
+
+static void usage(void) {
+	fprintf(stderr, "usage topt [-t] [-o outfile] [file...]\n");
+	exit(EXIT_FAILURE);
+}


### PR DESCRIPTION
* Reflow the header comment and make the intent clear

  Clean up the header comment to make clear that this
  is translating bytes into lines of text.

* Use consistent indentation style and formatting

  Previously, the code mixed tabs and spaces (even in the
  same function!). Standardize on four-space indent using
  space literals instead of a mix of tabs and spaces.
  Continuation lines are indented to the start of the
  argument list; hanging indent for continued boolean
  expressions.  Consistent spacing around operators.
  Remove trailing whitespace from lines.

* Use named constants instead of magic numbers

  Instead of `0200`, `0212 and `0215`, use `HIGH_BIT`,
  `NL` and `CR`, respectively.

* Use existing abstractions

  The `putCharInOctal` function amounted to,
  `fprintf(fp, "%03o\n", (unsigned char)c);`  Use that instead
  of open-coded shifts and masks.  Rename it and change the
  argument type to more meaningfully convey what it does, which
  is convert _bytes_ to octal.

* Avoid buffer overflow

  The construction of the output filename using strcpy/strcat
  into a small stack buffer provided opportunity for a trivial
  array-out-of-bounds error.  Use `snprintf` into a
  `FILENAME_MAX`-sized buffer instead.

* Check the return value of calls that can fail

  The previous version of the code did not check the return
  value of `fopen` for either the input or output files;
  if either file could not be opened for whatever reason,
  this would result in the corresponding file pointer being
  NULL and subsequently used incorrectly.  Added checks for
  errors, with meaningful error messages to stderr.

  Also, check for truncation when constructing the output
  filename.

* Properly validate command line options

  Use `getopt()` to properly validate command line options.
  Consider the cases of `topt -n -t` or `topt -r foo`
  previously.

* Add an explicit `return` at the end of `main`

  Previously, this had been relied on the implicit return 0
  behavior at the end of main, though given the rest of the
  code, that was more likely an error.

This PR is not an endorsement.

Signed-off-by: Dan Cross <crossd@gmail.com>